### PR TITLE
Hide "Move to Group" item, if user don't use Panorama

### DIFF
--- a/content/multipletab/multipletab.js
+++ b/content/multipletab/multipletab.js
@@ -3318,7 +3318,8 @@ var MultipleTabService = {
 	},
 	get canMoveTabsToGroup()
 	{
-		return 'TabView' in window && 'moveTabTo' in TabView && '_initFrame' in TabView;
+		return 'TabView' in window && 'moveTabTo' in TabView && '_initFrame' in TabView &&
+			TabView.firstUseExperienced;
 	},
    
 /* Move and Duplicate multiple tabs on Drag and Drop */ 


### PR DESCRIPTION
Like built-in context menu item behavior, see chrome://browser/content/browser.js

``` javascript
    document.getElementById("context_tabViewMenu").hidden =
      (this.contextTab.pinned || !TabView.firstUseExperienced);
```
