### PR TITLE
Use built-in string.trim()

### DIFF
--- a/content/multipletab/multipletab.js
+++ b/content/multipletab/multipletab.js
@@ -3252,7 +3252,7 @@ var MultipleTabService = {
 					break;
 			}
 			if (title)
-				title = title.replace(/^\s+|\s+$/g, '');
+				title = title.trim();
 		}
 
 		for (let i = 0, maxi = aTabs.length; i < maxi; i++)


### PR DESCRIPTION
Old versions w/o <a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String/Trim">trim()</a> aren't supported.
