### PR TITLE
Correctly save private tabs: use source document from tab.linkedBrowser

### DIFF
--- a/content/multipletab/multipletab.js
+++ b/content/multipletab/multipletab.js
@@ -2642,7 +2642,7 @@ var MultipleTabService = {
 				null, // title of picker
 				autoChosen,
 				b.referringURI, // referrer
-				document, // initiating document
+				b.contentDocument, // initiating document
 				true, // skip prompt?
 				null // cache key
 			);


### PR DESCRIPTION
This is for <a href="https://addons.mozilla.org/addon/private-tab/">Private Tab</a> extension.
