### PR TITLE
Fix: 'Close Selected Tabs' not working in FF 29+

### DIFF
--- a/content/multipletab/multipletab.js
+++ b/content/multipletab/multipletab.js
@@ -224,10 +224,18 @@ var MultipleTabService = {
 			)
 			return true;
 		var checked = { value: true };
+		var message;
+		try { // Firefox29-
+			message = this.tabbrowserBundle.getFormattedString('tabs.closeWarningMultipleTabs', [aTabsCount]);
+		}
+		catch (ex) { // Firefox30+
+			message = PluralForm.get(aTabsCount, this.tabbrowserBundle.getString('tabs.closeWarningMultiple')).
+					  replace("#1", aTabsCount);
+		}
 		window.focus();
 		var shouldClose = Services.prompt.confirmEx(window,
 				this.tabbrowserBundle.getString('tabs.closeWarningTitle'),
-				this.tabbrowserBundle.getFormattedString('tabs.closeWarningMultipleTabs', [aTabsCount]),
+				message,
 				(Services.prompt.BUTTON_TITLE_IS_STRING * Services.prompt.BUTTON_POS_0) +
 				(Services.prompt.BUTTON_TITLE_CANCEL * Services.prompt.BUTTON_POS_1),
 				this.tabbrowserBundle.getString('tabs.closeButtonMultiple'),


### PR DESCRIPTION
fix: https://github.com/piroor/multipletab/issues/68
(backported from: https://github.com/gomita/firegestures/commit/d1bc2eb17ec41be4744e3f2abbc3489fa0b15fd6)
