### PR TITLE
Decode URIs, if network.standard-url.escape-utf8 = false (just like browser itself for location bar)

### DIFF
--- a/modules/documentToCopyText.js
+++ b/modules/documentToCopyText.js
@@ -72,12 +72,12 @@ function isFormatRequiresLoaded(aFormat) {
 }
 
 function mayDecodeURI(aURI) {
-	if (Services.prefs.getBoolPref('network.standard-url.escape-utf8'))
+	if (!aURI || Services.prefs.getBoolPref('network.standard-url.escape-utf8'))
 		return aURI;
 	// See chrome://browser/content/browser.js
 	var window = Services.wm.getMostRecentWindow('navigator:browser');
 	if (window && 'losslessDecodeURI' in window) try {
-		return window.losslessDecodeURI({ spec: aURI });
+		return window.losslessDecodeURI(window.makeURI(aURI));
 	}
 	catch(e) {
 		Components.utils.reportError(e);

--- a/modules/documentToCopyText.js
+++ b/modules/documentToCopyText.js
@@ -2,6 +2,7 @@ var EXPORTED_SYMBOLS = ['documentToCopyText', 'isFormatRequiresLoaded'];
 
 var Ci = Components.interfaces;
 
+Components.utils.import('resource://gre/modules/Services.jsm');
 Components.utils.import('resource://gre/modules/XPCOMUtils.jsm');
 
 XPCOMUtils.defineLazyModuleGetter(this, 'evaluateXPath', 'resource://multipletab-modules/xpath.js');
@@ -10,7 +11,7 @@ function documentToCopyText(aDocument, aParams) {
 	var format = aParams.format || '%URL%';
 	var now = aParams.now || new Date();
 	var doc = aDocument;
-	var uri = aParams.uri || doc.defaultView.location.href;
+	var uri = mayDecodeURI(aParams.uri || doc.defaultView.location.href);
 	var title = doc.title;
 	if (!title || uri == 'about:blank')
 		title = aParams.title;
@@ -68,4 +69,18 @@ function escapeForHTML(aString) {
 
 function isFormatRequiresLoaded(aFormat) {
 	return /%AUTHOR%|%AUTHOR_HTML(?:IFIED)?%|%DESC(?:RIPTION)?%|%DESC(?:RIPTION)?_HTML(?:IFIED)?%|%KEYWORDS%%KEYWORDS_HTML(?:IFIED)?%/i.test(aFormat);
+}
+
+function mayDecodeURI(aURI) {
+	if (Services.prefs.getBoolPref('network.standard-url.escape-utf8'))
+		return aURI;
+	// See chrome://browser/content/browser.js
+	var window = Services.wm.getMostRecentWindow('navigator:browser');
+	if (window && 'losslessDecodeURI' in window) try {
+		return window.losslessDecodeURI({ spec: aURI });
+	}
+	catch(e) {
+		Components.utils.reportError(e);
+	}
+	return aURI;
 }


### PR DESCRIPTION
E.g. to copy https://ru.wikipedia.org/wiki/Служебная:Поиск instead of https://ru.wikipedia.org/wiki/%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F:%D0%9F%D0%BE%D0%B8%D1%81%D0%BA

P.S. Originally works only for location bar, but not for "Copy Link Location" from page context menu, so may be is needed some additional preference to disable introduced behavior.