### PR TITLE
One more RU Locale Update: "Invert Selection" and "Select Similar Tabs"

### DIFF
--- a/locale/ru/multipletab/multipletab.dtd
+++ b/locale/ru/multipletab/multipletab.dtd
@@ -17,7 +17,7 @@
 <!ENTITY popup.selection.unpinTabs       "Открепить вкладки">
 <!ENTITY popup.selection.moveToGroup     "Переместить в группу">
 <!ENTITY popup.selection.moveToGroup.new "Новая группа">
-<!ENTITY popup.selection.invertSelection "Инвертировать выбор">
+<!ENTITY popup.selection.invertSelection "Обратить выделение">
 
 <!ENTITY popup.context.removeLeftTabs.horizontal  "Закрыть вкладки слева">
 <!ENTITY popup.context.removeLeftTabs.vertical    "Закрыть вкладки выше">
@@ -36,7 +36,7 @@
 <!ENTITY popup.context.saveTabs.type.file      "Исключать встроенные ресурсы">
 <!ENTITY popup.context.saveTabs.type.complete     "Включать встроенные ресурсы">
 <!ENTITY popup.context.saveTabs.type.text         "Преобразовывать в текстовые файлы">
-<!ENTITY popup.context.selectSimilar              "Выбрать похожие вкладки">
+<!ENTITY popup.context.selectSimilar              "Выбрать схожие вкладки">
 
 
 


### PR DESCRIPTION
I guess "Обратить выделение" is more usual and clear translation than "Инвертировать выбор". For example, my variant is used in Russian versions of Photoshop, Excel etc.

The term "Similar" is translated as "Схожий" everywhere in this addon and e.g. Tab Mix Plus. Using a synonym "Похожий" we make the translation less uniform and understandable.