### PR TITLE
Closes #118 fix Move to group menu

### DIFF
--- a/content/multipletab/multipletab.js
+++ b/content/multipletab/multipletab.js
@@ -3388,21 +3388,7 @@ var MultipleTabService = aGlobal.MultipleTabService = inherit(MultipleTabHandler
 	// see http://mxr.mozilla.org/mozilla-central/ident?i=TabView__createGroupMenuItem
 	_createMoveToGroupItem : function MTS_createMoveToGroupItem(aGroupItem)
 	{
-		let title = aGroupItem.getTitle().trim();
-		if (!title) {
-			let topChildLabel = aGroupItem.getTopChild().tab.label;
-			let childNum = aGroupItem.getChildren().length;
-			title = gNavigatorBundle.getString('tabview.moveToUnnamedGroup.label');
-			if (childNum > 1 && title) {
-				let num = childNum - 1;
-				title = PluralForm.get(num, title)
-							.replace('#1', topChildLabel)
-							.replace('#2', num);
-			}
-			else {
-				title = topChildLabel;
-			}
-		}
+		let title = aGroupItem.getTitle(true).trim();
 		let item = document.createElement('menuitem');
 		item.setAttribute('label', title);
 		item.setAttribute('group-id', aGroupItem.id);


### PR DESCRIPTION
MTH's Move to Group menu was trying to use a label in the browser's bundle that doesn't exist anymore. This of course threw and never finished populating the menu if there were groups with no name.

In the Tab Groups add-on, calling ```groupItem.getTitle()``` will return the user-set title or blank if none was set, just like before. But passing a true argument like ```groupItem.getTitle(true);``` will ensure that if there is no user-set title, it will still return a title based on the group's id (e.g. Group 5), so it never returns blank.