### PR TITLE
Optimizations for Tree Style Tab selection.

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -153,13 +153,11 @@ function onTSTAPIMessage(message) {
       return DragSelectionManager.onDragEnd(message);
 
     case Constants.kTSTAPI_NOTIFY_SIDEBAR_SHOW:
-      Selection.getAllTabs(message.windowId || message.window).then(tabs => {
-        Selection.notifyTabStateToTST(
-          tabs,
-          [Constants.kSELECTED, Constants.kREADY_TO_CLOSE],
-          false
-        );
-      });
+      Selection.clearTabStateFromTST(
+        message.windowId || message.window.id,
+        [Constants.kSELECTED, Constants.kREADY_TO_CLOSE],
+        false
+      );
       return;
   }
 }
@@ -302,10 +300,10 @@ async function registerToTST() {
       `
     }).catch(handleMissingReceiverError);
 
-    const allWindows = await browser.windows.getAll({ populate: true });
+    const allWindows = await browser.windows.getAll({ populate: false });
     for (const window of allWindows) {
-      Selection.notifyTabStateToTST(
-        window.tabs,
+      Selection.clearTabStateFromTST(
+        window.id,
         [Constants.kSELECTED, Constants.kREADY_TO_CLOSE],
         false
       );

--- a/webextensions/common/drag-selection.js
+++ b/webextensions/common/drag-selection.js
@@ -270,7 +270,7 @@ export default class DragSelection {
       tabs.push(this.lastClickedTab || lastActiveTab);
       const selectedTabIds = tabs.map(tab => tab.id);
       if (!ctrlKeyPressed) {
-        for (const tab of window.tabs.filter(tab => !selectedTabIds.includes(tab.id))) {
+        for (const tab of this.selectedTabs.filter(tab => !selectedTabIds.includes(tab.id))) {
           this.delete(tab);
         }
       }

--- a/webextensions/common/drag-selection.js
+++ b/webextensions/common/drag-selection.js
@@ -56,8 +56,8 @@ export default class DragSelection {
     const tabs = force ? (await Selection.getAllTabs(this.windowId)) : this.selectedTabs;
     if (tabs.length > 0) {
       await Promise.all([
-        Selection.notifyTabStateToTST(
-          tabs.map(tab => tab.id),
+        (force ? Selection.clearTabStateFromTST : Selection.notifyTabStateToTST)(
+          force ? this.windowId : tabs.map(tab => tab.id),
           [Constants.kSELECTED, Constants.kREADY_TO_CLOSE],
           false
         ),

--- a/webextensions/common/drag-selection.js
+++ b/webextensions/common/drag-selection.js
@@ -250,7 +250,7 @@ export default class DragSelection {
     const ctrlKeyPressed = /^Mac/i.test(navigator.platform) ? message.metaKey : message.ctrlKey;
     if (!ctrlKeyPressed && !message.shiftKey) {
       log('regular click');
-      await this.clear(this.inSelectionSession);
+      await this.clear();
       this.inSelectionSession = false;
       this.lastClickedTab = null;
       return false;
@@ -355,7 +355,7 @@ export default class DragSelection {
   async onDragReadyInternal(message) {
     log('onDragReady', message);
 
-    await this.clear(true);
+    await this.clear();
     this.dragEnteredCount = 1;
     this.willCloseSelectedTabs = message.startOnClosebox;
     this.state = this.willCloseSelectedTabs ? Constants.kREADY_TO_CLOSE : Constants.kSELECTED ;

--- a/webextensions/common/drag-selection.js
+++ b/webextensions/common/drag-selection.js
@@ -250,7 +250,7 @@ export default class DragSelection {
     const ctrlKeyPressed = /^Mac/i.test(navigator.platform) ? message.metaKey : message.ctrlKey;
     if (!ctrlKeyPressed && !message.shiftKey) {
       log('regular click');
-      await this.clear(true);
+      await this.clear(this.inSelectionSession);
       this.inSelectionSession = false;
       this.lastClickedTab = null;
       return false;

--- a/webextensions/common/selection.js
+++ b/webextensions/common/selection.js
@@ -182,6 +182,31 @@ export async function invert(windowId) {
   requestUpdateHighlightedState({ selected: selection.unselected });
 }
 
+export async function clearTabStateFromTST(windowId, state, value = false) {
+
+  const tstTabs = await browser.runtime.sendMessage(Constants.kTST_ID, {
+    type: 'get-tree',
+    window: windowId,
+    tabs: '*',
+  }).catch(handleMissingReceiverError);
+  if (!tstTabs)
+    return; // TST not found/ready.
+
+  const affectedStates = Array.isArray(state) ? state : [state];
+  const affectedTabs = tstTabs.filter(tab => tab.states.some(tabState => {
+    let hasState = affectedStates.includes(tabState);
+    if (value) {
+      // Add state => Only need to update tab if the tab doesn't have a wanted state.
+      return !hasState;
+    } else {
+      // Remove state => Only need to update tab if it has an affected state.
+      return hasState;
+    }
+  }));
+
+  return notifyTabStateToTST(affectedTabs, state, value);
+}
+
 export async function notifyTabStateToTST(tabIds, state, value) {
   if (!Array.isArray(tabIds))
     tabIds = [tabIds];

--- a/webextensions/common/selection.js
+++ b/webextensions/common/selection.js
@@ -113,9 +113,9 @@ function requestUpdateHighlightedState(params = {}) {
 export async function clear(windowId, force = false) {
   if (!windowId)
     windowId = (await getActiveWindow()).id;
-  const selectedTabs = await (force ? getAllTabs(windowId) : getSelection(windowId));
+  const selectedTabs = await (force ? /* getAllTabs(windowId) */ null : getSelection(windowId));
   await Promise.all([
-    notifyTabStateToTST(selectedTabs.map(tab => tab.id), Constants.kSELECTED, false),
+    (force ? clearTabStateFromTST : notifyTabStateToTST)(force ? windowId : selectedTabs.map(tab => tab.id), Constants.kSELECTED, false),
     requestUpdateHighlightedState({ clear: true })
   ]);
 }


### PR DESCRIPTION
There was some performance regressions in MTH v3.0.0 and also some things that has poor performance before as well. In MTH v3.0.0 it takes several seconds each time I click on a tab before it becomes active. This is because each click force clears all selection in the current window. The bottleneck in this operation is removing the Tree Style Tab states from all tabs. 

I improved the performance by querying TST for all tabs in a window and then filtering the tabs based on the tab.states property that indicates which classes are added to a certain tab element. This noticeably improved performance both when the extension is started and when selection is cleared at other times.

It also seemed wasteful to force clear selection for every tab click since most of the time multi selected tabs are not in use and the user just wants to switch tab. Therefore I made a commit to only force clear selection when some tabs were known to be selected. This meant that clicking on tabs in normal cases were fast but clearing a selection was still slow. 

I think that never force clearing selection could also be a reasonable choice since in my case it seems to more than double performance when clearing a selection. Otherwise maybe only force clearing selection if there is less then a certain number of tabs in the affected window or maybe a hidden setting to toggle the behavior?

I also optimized shift clicks since they cleared the TST state from all tabs for each click which took a long time. Now it instead only clears TST states from cached selected tabs which is a lot faster.