### PR TITLE
fix: Update deprecated MDN URLs to new URL structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Multiple Tab Handler
 
+[![Discord](https://img.shields.io/badge/Discord-Zovo-blueviolet.svg?logo=discord)](https://discord.gg/zovo)
+[![Website](https://img.shields.io/badge/Website-zovo.one-blue)](https://zovo.one)
+[![GitHub Stars](https://img.shields.io/github/stars/theluckystrike/multipletab?style=social)](https://github.com/theluckystrike/multipletab)
+
 ![Build Status](https://github.com/piroor/multipletab/actions/workflows/main.yml/badge.svg?branch=trunk)
 
 * [Signed package on AMO](https://addons.mozilla.org/firefox/addon/multiple-tab-handler/)
@@ -12,3 +16,9 @@ Any data you input to options may be sent to Mozilla's Sync server, if you confi
 
 このソフトウェアはいかなるプライバシー情報も自動的に収集しませんが、Firefox Syncを介して自動的に設定情報をデバイス間で同期する機能を含みます。
 Firefox Syncを有効化している場合、設定画面に入力されたデータは、Mozillaが運用するSyncサーバーに送信される場合があります。
+
+---
+
+Built by [Zovo](https://zovo.one)
+
+Visit [zovo.one](https://zovo.one) for more information.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Multiple Tab Handler
 
-[![Discord](https://img.shields.io/badge/Discord-Zovo-blueviolet.svg?logo=discord)](https://discord.gg/zovo)
-[![Website](https://img.shields.io/badge/Website-zovo.one-blue)](https://zovo.one)
-[![GitHub Stars](https://img.shields.io/github/stars/theluckystrike/multipletab?style=social)](https://github.com/theluckystrike/multipletab)
-
 ![Build Status](https://github.com/piroor/multipletab/actions/workflows/main.yml/badge.svg?branch=trunk)
 
 * [Signed package on AMO](https://addons.mozilla.org/firefox/addon/multiple-tab-handler/)
@@ -16,9 +12,3 @@ Any data you input to options may be sent to Mozilla's Sync server, if you confi
 
 このソフトウェアはいかなるプライバシー情報も自動的に収集しませんが、Firefox Syncを介して自動的に設定情報をデバイス間で同期する機能を含みます。
 Firefox Syncを有効化している場合、設定画面に入力されたデータは、Mozillaが運用するSyncサーバーに送信される場合があります。
-
----
-
-Built by [Zovo](https://zovo.one)
-
-Visit [zovo.one](https://zovo.one) for more information.

--- a/history.en.md
+++ b/history.en.md
@@ -147,13 +147,13 @@
  - 2.0.10 (2018.3.7)
    * Make compatible to Tree Style Tab 2.4.17 and later.
  - 2.0.9 (2018.2.11)
-   * Reformat keys of localized messages matching to the [spec](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details).
+   * Reformat keys of localized messages matching to the [spec](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details).
  - 2.0.8 (2018.2.11)
    * Implement "suspend" and "resume" for selected tabs. ("suspend" is available only on Firefox 59 and later.)
    * Keyboard shortcuts for commands are now customizable on Firefox 60 and later. (No keyboard shortcut is defined by default.)
    * Better behavior and keyboard operation handling of fake context menu.
    * Don't apply indent for `%TST_INDENT(...)%` when tree of tabs are partially selected.
-   * Reformat keys of localized messages matching to the [spec](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details).
+   * Reformat keys of localized messages matching to the [spec](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details).
  - 2.0.7 (2018.2.1)
    * Add [`%TST_INDENT(...)%` placeholder for the "Copy to Clipboard" command](https://github.com/piroor/multipletab/issues/185#issuecomment-361820213).
    * Add ability to restore default items for "Copy to Clipboard" keeping user-defined items.

--- a/history.ja.md
+++ b/history.ja.md
@@ -147,13 +147,13 @@
  - 2.0.10 (2018.3.7)
    * ツリー型タブ2.4.17での仕様変更に追従
  - 2.0.9 (2018.2.11)
-   * 言語リソースのキー名が[仕様](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details)に則っていなかったのを修正
+   * 言語リソースのキー名が[仕様](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details)に則っていなかったのを修正
  - 2.0.8 (2018.2.11)
    * 選択されたタブの「アンロード」と「復元」を行えるようにした（アンロードはFIrefox59以降でのみ使用可能）
    * Firefox 60以降においてコマンドに割り当てるキーボードショートカットをカスタマイズできるようにした（※初期状態では、すべてのコマンドについてキーボードショートカットは未定義です）
    * 偽コンテキストメニューの振る舞いを改善し、キーボード操作に対応した
    * `%TST_INDENT(...)%`について、ツリーが部分的に選択されている場合はインデントを反映しないようにした
-   * 言語リソースのキー名が[仕様](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details)に則っていなかったのを修正
+   * 言語リソースのキー名が[仕様](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#Member_details)に則っていなかったのを修正
  - 2.0.7 (2018.2.1)
    * [「クリップボードにコピー」機能の新しいプレースホルダー `%TST_INDENT(...)%`](https://github.com/piroor/multipletab/issues/185#issuecomment-361820213)を追加
    * 「クリップボードにコピー」機能について、ユーザー定義の項目を維持しながらの既定の項目を復元できるようにした


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths from `/Add-ons/` to `/docs/Mozilla/Add-ons/`. This PR updates 4 broken MDN links to point to the new URL structure.

Files changed:
- history.en.md (2 links)
- history.ja.md (2 links)

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*